### PR TITLE
[FEAT] Make memory leak tests much more strict

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -329,13 +329,15 @@ test_leaks() {
 			definitely_lost=$(cat tmp_valgrind-out.txt | grep "definitely lost:" | awk 'END{print $4}')
 			possibly_lost=$(cat tmp_valgrind-out.txt | grep "possibly lost:" | awk 'END{print $4}')
 			indirectly_lost=$(cat tmp_valgrind-out.txt | grep "indirectly lost:" | awk 'END{print $4}')
+			error_summary=$(cat tmp_valgrind-out.txt | grep "ERROR SUMMARY:" | awk 'END{print $4}')
 			# echo "$definitely_lost"
 			# echo "$possibly_lost"
 			# echo "$indirectly_lost"
 			# Check if any bytes were lost
 			if ([ -n "$definitely_lost" ] && [ "$definitely_lost" -ne 0 ]) || \
 				([ -n "$possibly_lost" ] && [ "$possibly_lost" -ne 0 ]) || \
-				([ -n "$indirectly_lost" ] && [ "$indirectly_lost" -ne 0 ]);
+				([ -n "$indirectly_lost" ] && [ "$indirectly_lost" -ne 0 ]) || \
+				([ -n "$error_summary" ] && [ "$error_summary" -ne 0 ]);
 			then
 				echo -ne "❌ "
 				((LEAKS++))

--- a/tester.sh
+++ b/tester.sh
@@ -269,6 +269,7 @@ test_leaks() {
 	--suppressions=$MINISHELL_PATH/minishell.supp
 	--trace-children=yes
 	--trace-children-skip=$(echo $(which $valgrind_ignore) | tr ' ' ',')
+	--track-fds=yes	# Change to --track-fds=all later
 	--track-origins=yes
 	--verbose
 	--log-file=tmp_valgrind-out.txt)
@@ -351,6 +352,12 @@ test_leaks() {
 					break
 				fi
 			done
+			# Get all open file descriptors not inherited from parent
+			open_file_descriptors=$(awk '/Open file descriptor/ {fd=$0; getline; if ($0 !~ /<inherited from parent>/) print fd}' tmp_valgrind-out.txt)
+			if [ -n "$open_file_descriptors" ]
+			then
+				leak_found=1
+			fi
 			if [ "$leak_found" -ne 0 ]
 			then
 				echo -ne "❌ "

--- a/tester.sh
+++ b/tester.sh
@@ -85,7 +85,11 @@ main() {
 	rm -rf test
 
 	echo "$GH_BRANCH=$FAILED" >> "$GITHUB_ENV"
-	exit $LEAKS
+	if [[ $LEAKS -ne 0 ]] ; then
+		exit 1
+	else
+		exit 0
+	fi
 }
 
 test_no_env() {

--- a/tester.sh
+++ b/tester.sh
@@ -259,8 +259,8 @@ test_from_file() {
 }
 
 test_leaks() {
-	valgrind_ignore="cat chmod cp diff find git grep head ls make man mkdir mv \
-	ncdu norminette ps rm sort tail time top touch wc which yes"
+	valgrind_ignore_rel_path="norminette"
+	valgrind_ignore_abs_path="/bin/* /usr/bin/*"
 	valgrind_flags=(
 	--errors-for-leak-kinds=all
 	--leak-check=full
@@ -268,7 +268,7 @@ test_leaks() {
 	--show-leak-kinds=all
 	--suppressions=$MINISHELL_PATH/minishell.supp
 	--trace-children=yes
-	--trace-children-skip=$(echo $(which $valgrind_ignore) | tr ' ' ',')
+	--trace-children-skip=$(echo $valgrind_ignore_abs_path $(which $valgrind_ignore_rel_path) | tr ' ' ',')
 	--track-fds=yes	# Change to --track-fds=all later
 	--track-origins=yes
 	--verbose


### PR DESCRIPTION
- I added all the important valgrind flags from our Makefile to the tester for its memory leak tests.
- Now it also report file descriptor leaks that are not inherited from a parent process as leaks.
---
- [x] Most likely more commands need to be added to the valgrind_ignore to not report leaks from external commands as failures.