### PR TITLE
[FEAT] Save valgrind output in files

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -4,6 +4,7 @@
 export MINISHELL_PATH=./
 export EXECUTABLE=minishell
 RUNDIR=$HOME/42_minishell_tester
+VALGRIND_OUTDIR=$MINISHELL_PATH/valgrind_output
 
 NL=$'\n'
 TAB=$'\t'
@@ -281,6 +282,8 @@ test_leaks() {
 	i=1
 	end_of_file=0
 	line_count=0
+	dir_name=$(basename $(dirname $1))
+	file_name=$(basename --suffix=.sh $1)
 	while [[ $end_of_file == 0 ]] ;
 	do
 		read -r line
@@ -366,6 +369,8 @@ test_leaks() {
 			then
 				echo -ne "❌ "
 				((LEAKS++))
+				mkdir -p "$VALGRIND_OUTDIR/$dir_name/$file_name" 2>/dev/null
+				cat tmp_valgrind-out.txt > "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
 			else
 				echo -ne "✅ "
 			fi
@@ -386,6 +391,7 @@ test_leaks() {
 			fi
 		fi
 	done < "$1"
+	find "$VALGRIND_OUTDIR" -type d -empty -delete 2>/dev/null
 }
 
 test_without_env() {

--- a/tester.sh
+++ b/tester.sh
@@ -276,7 +276,6 @@ test_leaks() {
 	--trace-children-skip=$(echo $valgrind_ignore_abs_path $(which $valgrind_ignore_rel_path) | tr ' ' ',')
 	--track-fds=yes	# Change to --track-fds=all later
 	--track-origins=yes
-	--verbose
 	--log-file=tmp_valgrind-out.txt)
 	IFS=''
 	i=1


### PR DESCRIPTION
- Also remove --verbose flag from valgrind.
  It does not seem to be necessary and only makes it harder to read the important information from the valgrind output.