### PR TITLE
[FIX] Fix detection of fd leaks

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -358,8 +358,27 @@ test_leaks() {
 					break
 				fi
 			done
-			# Get all open file descriptors not inherited from parent
-			open_file_descriptors=$(awk '/Open file descriptor/ {fd=$0; getline; if ($0 !~ /<inherited from parent>/) print fd}' tmp_valgrind-out.txt)
+			# Check if there are any open file descriptors not inherited from parent
+			open_file_descriptors=$(
+				awk '
+					# If the line starts with a PID and "Open file descriptor"
+					/^==[0-9]+== Open file descriptor/
+					{
+						# Store the PID and the line
+						pid=$1
+						line=$0
+
+						# Keep reading lines until a line that starts with the same PID gets found
+						while (getline && $1 != pid);
+
+						# Check if the line does not contain "<inherited from parent>"
+						if ($0 !~ /<inherited from parent>/)
+						{
+							print line
+						}
+					}
+				' tmp_valgrind-out.txt
+			)
 			if [ -n "$open_file_descriptors" ]
 			then
 				leak_found=1

--- a/tester.sh
+++ b/tester.sh
@@ -362,8 +362,7 @@ test_leaks() {
 			open_file_descriptors=$(
 				awk '
 					# If the line starts with a PID and "Open file descriptor"
-					/^==[0-9]+== Open file descriptor/
-					{
+					/^==[0-9]+== Open file descriptor/ {
 						# Store the PID and the line
 						pid=$1
 						line=$0


### PR DESCRIPTION
For test cmds that start multiple child processes, the outputs of valgrind for each process can be interleaved. The previous `awk` command to detect open file descriptor errors from the valgrind output could not handle this.

Now, the `awk` command considers the pids of the valgrind output to fix this.