### PR TITLE
[FEAT] Save failed outputs into persistent output directory

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -5,7 +5,7 @@ export MINISHELL_PATH=./
 export EXECUTABLE=minishell
 RUNDIR=$HOME/42_minishell_tester
 TMP_OUTDIR=/tmp/minishell_tester
-VALGRIND_OUTDIR=$MINISHELL_PATH/valgrind_output
+OUTDIR=$MINISHELL_PATH/tester_output
 
 NL=$'\n'
 TAB=$'\t'
@@ -187,6 +187,8 @@ test_from_file() {
 	i=1
 	end_of_file=0
 	line_count=0
+	dir_name=$(basename $(dirname $1))
+	file_name=$(basename --suffix=.sh $1)
 	while [[ $end_of_file == 0 ]] ;
 	do
 		read -r line
@@ -220,6 +222,9 @@ test_from_file() {
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_OUT++))
 				((FAILED++))
+				mkdir -p "$OUTDIR/$dir_name/$file_name" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_out_minishell" "$OUTDIR/$dir_name/$file_name/stdout_minishell_$i" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_out_bash" "$OUTDIR/$dir_name/$file_name/stdout_bash_$i" 2>/dev/null
 			else
 				echo -ne "✅  "
 				((TEST_OK++))
@@ -231,6 +236,9 @@ test_from_file() {
 				echo -ne "❌  " |  tr '\n' ' '
 				((TEST_KO_ERR++))
 				((FAILED++))
+				mkdir -p "$OUTDIR/$dir_name/$file_name" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_err_minishell" "$OUTDIR/$dir_name/$file_name/stderr_minishell_$i" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_err_bash" "$OUTDIR/$dir_name/$file_name/stderr_bash_$i" 2>/dev/null
 			else
 				echo -ne "✅  "
 				((TEST_OK++))
@@ -263,16 +271,6 @@ test_from_file() {
 				THREE=0
 			fi
 		fi
-		# echo
-		# echo -n "minishell stdout: " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_out_minishell" | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
-		# echo
-		# echo -n "bash stdout:      " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_out_bash" | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
-		# echo
-		# echo
-		# echo -n "minishell stderr: " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_err_minishell" | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
-		# echo
-		# echo -n "bash stderr:      " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_err_bash" | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
-		# echo
 	done < "$1"
 }
 
@@ -398,8 +396,8 @@ test_leaks() {
 			then
 				echo -ne "❌ "
 				((LEAKS++))
-				mkdir -p "$VALGRIND_OUTDIR/$dir_name/$file_name" 2>/dev/null
-				mv "$TMP_OUTDIR/tmp_valgrind_out" "$VALGRIND_OUTDIR/$dir_name/$file_name/valgrind_out_$i" 2>/dev/null
+				mkdir -p "$OUTDIR/$dir_name/$file_name" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_valgrind_out" "$OUTDIR/$dir_name/$file_name/valgrind_out_$i" 2>/dev/null
 			else
 				echo -ne "✅ "
 			fi
@@ -421,7 +419,7 @@ test_leaks() {
 		fi
 	done < "$1"
 	rm -f "$TMP_OUTDIR/tmp_valgrind_out"
-	find "$VALGRIND_OUTDIR" -type d -empty -delete 2>/dev/null
+	find "$OUTDIR" -type d -empty -delete 2>/dev/null
 }
 
 test_without_env() {
@@ -429,6 +427,8 @@ test_without_env() {
 	i=1
 	end_of_file=0
 	line_count=0
+	dir_name=$(basename $(dirname $1))
+	file_name=$(basename --suffix=.sh $1)
 	while [[ $end_of_file == 0 ]] ;
 	do
 		read -r line
@@ -462,6 +462,9 @@ test_without_env() {
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_OUT++))
 				((FAILED++))
+				mkdir -p "$OUTDIR/$dir_name/$file_name" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_out_minishell" "$OUTDIR/$dir_name/$file_name/stdout_minishell_$i" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_out_bash" "$OUTDIR/$dir_name/$file_name/stdout_bash_$i" 2>/dev/null
 			else
 				echo -ne "✅  "
 				((TEST_OK++))
@@ -473,6 +476,9 @@ test_without_env() {
 				echo -ne "❌  " |  tr '\n' ' '
 				((TEST_KO_ERR++))
 				((FAILED++))
+				mkdir -p "$OUTDIR/$dir_name/$file_name" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_err_minishell" "$OUTDIR/$dir_name/$file_name/stderr_minishell_$i" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_err_bash" "$OUTDIR/$dir_name/$file_name/stderr_bash_$i" 2>/dev/null
 			else
 				echo -ne "✅  "
 				((TEST_OK++))

--- a/tester.sh
+++ b/tester.sh
@@ -399,7 +399,7 @@ test_leaks() {
 				echo -ne "❌ "
 				((LEAKS++))
 				mkdir -p "$VALGRIND_OUTDIR/$dir_name/$file_name" 2>/dev/null
-				cat "$TMP_OUTDIR/tmp_valgrind-out.txt" > "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_valgrind-out.txt" "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
 			else
 				echo -ne "✅ "
 			fi

--- a/tester.sh
+++ b/tester.sh
@@ -289,7 +289,7 @@ test_leaks() {
 	--trace-children-skip=$(echo "$valgrind_ignore_abs_path" $(which "$valgrind_ignore_rel_path") | tr ' ' ',')
 	--track-fds=yes	# Change to --track-fds=all later
 	--track-origins=yes
-	--log-file="$TMP_OUTDIR/tmp_valgrind-out.txt")
+	--log-file="$TMP_OUTDIR/tmp_valgrind_out")
 	IFS=''
 	i=1
 	end_of_file=0
@@ -359,7 +359,7 @@ test_leaks() {
 			echo -ne "\033[1;36mLEAKS:\033[m "
 			echo -n "$INPUT" | eval "valgrind ${valgrind_flags[@]} $MINISHELL_PATH/$EXECUTABLE" 2>/dev/null >/dev/null
 			# Get all error summaries
-			error_summaries=$(cat "$TMP_OUTDIR/tmp_valgrind-out.txt" | grep -a "ERROR SUMMARY:" | awk '{print $4}')
+			error_summaries=$(cat "$TMP_OUTDIR/tmp_valgrind_out" | grep -a "ERROR SUMMARY:" | awk '{print $4}')
 			IFS=$'\n' read -rd '' -a error_summaries_array <<<"$error_summaries"
 			# Check if any error summary is not 0
 			leak_found=0
@@ -388,7 +388,7 @@ test_leaks() {
 							print line
 						}
 					}
-				' "$TMP_OUTDIR/tmp_valgrind-out.txt"
+				' "$TMP_OUTDIR/tmp_valgrind_out"
 			)
 			if [ -n "$open_file_descriptors" ]
 			then
@@ -399,7 +399,7 @@ test_leaks() {
 				echo -ne "❌ "
 				((LEAKS++))
 				mkdir -p "$VALGRIND_OUTDIR/$dir_name/$file_name" 2>/dev/null
-				mv "$TMP_OUTDIR/tmp_valgrind-out.txt" "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
+				mv "$TMP_OUTDIR/tmp_valgrind_out" "$VALGRIND_OUTDIR/$dir_name/$file_name/valgrind_out_$i" 2>/dev/null
 			else
 				echo -ne "✅ "
 			fi
@@ -420,7 +420,7 @@ test_leaks() {
 			fi
 		fi
 	done < "$1"
-	rm -f "$TMP_OUTDIR/tmp_valgrind-out.txt"
+	rm -f "$TMP_OUTDIR/tmp_valgrind_out"
 	find "$VALGRIND_OUTDIR" -type d -empty -delete 2>/dev/null
 }
 

--- a/tester.sh
+++ b/tester.sh
@@ -210,12 +210,12 @@ test_from_file() {
 				((line_count++))
 			done
 			# INPUT=${INPUT%?}
-			echo -n "$INPUT" | $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR"/tmp_err_minishell >"$TMP_OUTDIR"/tmp_out_minishell
+			echo -n "$INPUT" | $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
 			exit_minishell=$?
-			echo -n "enable -n .$NL$INPUT" | bash --posix 2>"$TMP_OUTDIR"/tmp_err_bash >"$TMP_OUTDIR"/tmp_out_bash
+			echo -n "enable -n .$NL$INPUT" | bash --posix 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
 			exit_bash=$?
 			echo -ne "\033[1;34mSTD_OUT:\033[m "
-			if ! diff -q "$TMP_OUTDIR"/tmp_out_minishell "$TMP_OUTDIR"/tmp_out_bash >/dev/null ;
+			if ! diff -q "$TMP_OUTDIR/tmp_out_minishell" "$TMP_OUTDIR/tmp_out_bash" >/dev/null ;
 			then
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_OUT++))
@@ -264,14 +264,14 @@ test_from_file() {
 			fi
 		fi
 		# echo
-		# echo -n "minishell stdout: " ; echo -n "|" ; cat "$TMP_OUTDIR"/tmp_out_minishell | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
+		# echo -n "minishell stdout: " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_out_minishell" | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
 		# echo
-		# echo -n "bash stdout:      " ; echo -n "|" ; cat "$TMP_OUTDIR"/tmp_out_bash | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
+		# echo -n "bash stdout:      " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_out_bash" | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
 		# echo
 		# echo
-		# echo -n "minishell stderr: " ; echo -n "|" ; cat "$TMP_OUTDIR"/tmp_err_minishell | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
+		# echo -n "minishell stderr: " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_err_minishell" | nl -ba | awk '{print "m: " $0}' ; echo -n "|"
 		# echo
-		# echo -n "bash stderr:      " ; echo -n "|" ; cat "$TMP_OUTDIR"/tmp_err_bash | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
+		# echo -n "bash stderr:      " ; echo -n "|" ; cat "$TMP_OUTDIR/tmp_err_bash" | nl -ba | awk '{print "b: " $0}' ; echo -n "|"
 		# echo
 	done < "$1"
 }
@@ -289,7 +289,7 @@ test_leaks() {
 	--trace-children-skip=$(echo "$valgrind_ignore_abs_path" $(which "$valgrind_ignore_rel_path") | tr ' ' ',')
 	--track-fds=yes	# Change to --track-fds=all later
 	--track-origins=yes
-	--log-file="$TMP_OUTDIR"/tmp_valgrind-out.txt)
+	--log-file="$TMP_OUTDIR/tmp_valgrind-out.txt")
 	IFS=''
 	i=1
 	end_of_file=0
@@ -319,12 +319,12 @@ test_leaks() {
 				((line_count++))
 			done
 			# INPUT=${INPUT%?}
-			echo -n "$INPUT" | $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR"/tmp_err_minishell >"$TMP_OUTDIR"/tmp_out_minishell
+			echo -n "$INPUT" | $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
 			exit_minishell=$?
-			echo -n "enable -n .$NL$INPUT" | bash --posix 2>"$TMP_OUTDIR"/tmp_err_bash >"$TMP_OUTDIR"/tmp_out_bash
+			echo -n "enable -n .$NL$INPUT" | bash --posix 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
 			exit_bash=$?
 			echo -ne "\033[1;34mSTD_OUT:\033[m "
-			if ! diff -q "$TMP_OUTDIR"/tmp_out_minishell "$TMP_OUTDIR"/tmp_out_bash >/dev/null ;
+			if ! diff -q "$TMP_OUTDIR/tmp_out_minishell" "$TMP_OUTDIR/tmp_out_bash" >/dev/null ;
 			then
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_OUT++))
@@ -359,7 +359,7 @@ test_leaks() {
 			echo -ne "\033[1;36mLEAKS:\033[m "
 			echo -n "$INPUT" | eval "valgrind ${valgrind_flags[@]} $MINISHELL_PATH/$EXECUTABLE" 2>/dev/null >/dev/null
 			# Get all error summaries
-			error_summaries=$(cat "$TMP_OUTDIR"/tmp_valgrind-out.txt | grep -a "ERROR SUMMARY:" | awk '{print $4}')
+			error_summaries=$(cat "$TMP_OUTDIR/tmp_valgrind-out.txt" | grep -a "ERROR SUMMARY:" | awk '{print $4}')
 			IFS=$'\n' read -rd '' -a error_summaries_array <<<"$error_summaries"
 			# Check if any error summary is not 0
 			leak_found=0
@@ -388,7 +388,7 @@ test_leaks() {
 							print line
 						}
 					}
-				' "$TMP_OUTDIR"/tmp_valgrind-out.txt
+				' "$TMP_OUTDIR/tmp_valgrind-out.txt"
 			)
 			if [ -n "$open_file_descriptors" ]
 			then
@@ -399,7 +399,7 @@ test_leaks() {
 				echo -ne "❌ "
 				((LEAKS++))
 				mkdir -p "$VALGRIND_OUTDIR/$dir_name/$file_name" 2>/dev/null
-				cat "$TMP_OUTDIR"/tmp_valgrind-out.txt > "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
+				cat "$TMP_OUTDIR/tmp_valgrind-out.txt" > "$VALGRIND_OUTDIR/$dir_name/$file_name/test_$i.txt" 2>/dev/null
 			else
 				echo -ne "✅ "
 			fi
@@ -420,7 +420,7 @@ test_leaks() {
 			fi
 		fi
 	done < "$1"
-	rm -f "$TMP_OUTDIR"/tmp_valgrind-out.txt
+	rm -f "$TMP_OUTDIR/tmp_valgrind-out.txt"
 	find "$VALGRIND_OUTDIR" -type d -empty -delete 2>/dev/null
 }
 
@@ -452,12 +452,12 @@ test_without_env() {
 				((line_count++))
 			done
 			# INPUT=${INPUT%?}
-			echo -n "$INPUT" | env -i $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR"/tmp_err_minishell >"$TMP_OUTDIR"/tmp_out_minishell
+			echo -n "$INPUT" | env -i $MINISHELL_PATH/$EXECUTABLE 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
 			exit_minishell=$?
-			echo -n "enable -n .$NL$INPUT" | env -i bash --posix 2>"$TMP_OUTDIR"/tmp_err_bash >"$TMP_OUTDIR"/tmp_out_bash
+			echo -n "enable -n .$NL$INPUT" | env -i bash --posix 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
 			exit_bash=$?
 			echo -ne "\033[1;34mSTD_OUT:\033[m "
-			if ! diff -q "$TMP_OUTDIR"/tmp_out_minishell "$TMP_OUTDIR"/tmp_out_bash >/dev/null ;
+			if ! diff -q "$TMP_OUTDIR/tmp_out_minishell" "$TMP_OUTDIR/tmp_out_bash" >/dev/null ;
 			then
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_OUT++))


### PR DESCRIPTION
The files can then later be used in our GH Actions to be printed out fully, or just the diff.