### PR TITLE
[FEAT] Change valgrind flag to `track-fds=all`

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -285,7 +285,7 @@ test_leaks() {
 	--suppressions="$MINISHELL_PATH"/minishell.supp
 	--trace-children=yes
 	--trace-children-skip=$(echo "$valgrind_ignore_abs_path" $(which "$valgrind_ignore_rel_path") | tr ' ' ',')
-	--track-fds=yes	# Change to --track-fds=all later
+	--track-fds=all
 	--track-origins=yes
 	--log-file="$TMP_OUTDIR/tmp_valgrind_out")
 	IFS=''


### PR DESCRIPTION
- [x] Merge just before merging https://github.com/LeaYeh/minishell/pull/144.

Then our minishell should also pass all memory leak tests with `track-fds=all`.