### PR TITLE
[FEAT] Diff the stderr

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -234,7 +234,8 @@ test_from_file() {
 				((ONE++))
 			fi
 			echo -ne "\033[1;33mSTD_ERR:\033[m "
-			if [[ -s $TMP_OUTDIR/tmp_err_minishell && ! -s $TMP_OUTDIR/tmp_err_bash ]] || [[ ! -s $TMP_OUTDIR/tmp_err_minishell && -s $TMP_OUTDIR/tmp_err_bash ]] ;
+			# Filter out the "crash" prefix from minishell error messages and the "bash: line X" prefix from bash error messages
+			if ! diff -q <(sed 's/^crash[^:]*//' $TMP_OUTDIR/tmp_err_minishell) <(sed 's/^bash: [^:]*//' $TMP_OUTDIR/tmp_err_bash) >/dev/null ;
 			then
 				echo -ne "❌  " |  tr '\n' ' '
 				((TEST_KO_ERR++))

--- a/tester.sh
+++ b/tester.sh
@@ -234,8 +234,15 @@ test_from_file() {
 				((ONE++))
 			fi
 			echo -ne "\033[1;33mSTD_ERR:\033[m "
-			# Filter out the "crash" prefix from minishell error messages and the "bash: line X" prefix from bash error messages
-			if ! diff -q <(sed 's/^crash[^:]*//' $TMP_OUTDIR/tmp_err_minishell) <(sed 's/^bash: [^:]*//' $TMP_OUTDIR/tmp_err_bash) >/dev/null ;
+			# Filter out program name prefix before first colon from minishell error messages and "bash: line X" prefix from bash error messages
+			stderr_minishell=$(cat "$TMP_OUTDIR/tmp_err_minishell")
+			stderr_bash=$(cat "$TMP_OUTDIR/tmp_err_bash")
+			if [[ $stderr_bash == bash:* ]] ;
+			then
+				stderr_bash=$(echo "$stderr_bash" | sed 's/^bash: line[^:]*//')
+				stderr_minishell=$(echo "$stderr_minishell" | sed 's/^[^:]*//')
+			fi
+			if ! diff -q <(echo "$stderr_minishell") <(echo "$stderr_bash") >/dev/null ;
 			then
 				echo -ne "❌  " |  tr '\n' ' '
 				((TEST_KO_ERR++))


### PR DESCRIPTION
The stderr for bash **most of the time** starts like this:
```
bash: line <X>: <error_msg>
```
After sed, it will look like this:
```
: <error_msg>
```

<br>

**For crash:**
Before sed:
```
crash: <error_msg>
```
After sed:
```
: <error_msg>
```

<br>

However, this makes the tester specific for our shell now. 
We should discuss together how to make it more generalized.