### PR TITLE
[FIX] Launch tester script in env with all signals set to default behavior

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S --default-signal bash
 
 # Change if you store the tester in another PATH
 export MINISHELL_PATH=./


### PR DESCRIPTION
This is to make sure that a modified signal handling of the running environment, especially of SIGPIPE, does not affect the test results.

For example, the default GitHub Actions runner inherits to all jobs to ignore SIGPIPE.
The behavior can be reproduced locally by running `trap '' SIGPIPE` and then commands that produce a SIGPIPE signal, like `cat | ls`.

A shell command like `trap - SIGPIPE` to reset the behavior to default does not work within a shell script.
> shell scripts don't support resetting signal handling to the default handler. I.E. The standard trap mechanism for controlling signals has no support for resetting a signal to its default handler, if it was ignored when the shell was started.

Try this to see for yourself:
```bash
trap '' SIGPIPE ; echo "trap - SIGPIPE ; (sleep 1 && echo 1) | echo 2" | bash
```
Compare to:
```bash
trap '' SIGPIPE ; echo "env --default-signal bash -c '(sleep 1 && echo 1) | echo 2'" | bash
```

To see all non-default signal handlers in the current environment:
```bash
env --list-signal-handling bash
```

- Reference about handling SIGPIPE:
  https://www.pixelbeat.org/programming/sigpipe_handling.html
- Reference about `#!/usr/bin/env -S`:
  https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html#g_t_002dS_002f_002d_002dsplit_002dstring-usage-in-scripts
- Reference about the behavior of GitHub Actions runner:
  https://github.com/actions/runner/issues/2684