### PR TITLE
Make regex for sed work with output from external commands as well

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -237,7 +237,7 @@ test_from_file() {
 			# Filter out program name prefix before first colon from minishell error messages and "bash: line X" prefix from bash error messages
 			stderr_minishell=$(cat "$TMP_OUTDIR/tmp_err_minishell")
 			stderr_bash=$(cat "$TMP_OUTDIR/tmp_err_bash")
-			if [[ $stderr_bash == bash:* ]] ;
+			if [[ $stderr_bash == *bash:* ]] ;
 			then
 				stderr_bash=$(echo "$stderr_bash" | sed 's/^\(bash: line\)\?[^:]*//')
 				stderr_minishell=$(echo "$stderr_minishell" | sed 's/^[^:]*//')

--- a/tester.sh
+++ b/tester.sh
@@ -239,7 +239,7 @@ test_from_file() {
 			stderr_bash=$(cat "$TMP_OUTDIR/tmp_err_bash")
 			if [[ $stderr_bash == bash:* ]] ;
 			then
-				stderr_bash=$(echo "$stderr_bash" | sed 's/^bash: line[^:]*//')
+				stderr_bash=$(echo "$stderr_bash" | sed 's/^\(bash: line\)\?[^:]*//')
 				stderr_minishell=$(echo "$stderr_minishell" | sed 's/^[^:]*//')
 			fi
 			if ! diff -q <(echo "$stderr_minishell") <(echo "$stderr_bash") >/dev/null ;


### PR DESCRIPTION
In some test cases, an external command like `cat` will print error messages on stderr, which would not match the regular expression in the sed command for the bash output.
For example on test 32 in the syntax errors check, the output would be:
```
cat: wouaf: No such file or directory
cat: wouaf: No such file or directory
bash: line 3: syntax error near unexpected token `newline'
bash: line 3: `>'
```
and after the current regular expression it would result in
```
cat: wouaf: No such file or directory
cat: wouaf: No such file or directory
: syntax error near unexpected token `newline'
: `>'
```
And then give a KO on the stderr because for the output of the minishell it would get rid of the `cat` at the start.

I modified the regex a bit so it would also work with error messages from external commands.