### PR TITLE
[FEAT] Add support for readline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Updates
 
+- Add support for readline.
 - More rigorous memory leak checks.
 - Memory leak checks in child processes without false positives from external commands.
 - File descriptor leak checks.
@@ -17,55 +18,17 @@
 
 # Menu
 
-[Setup](#setup)
-
 [Install & Run](#how-to-install-and-run)
 
 [Usage](#how-to-launch-the-tester)
 
 [CI with GitHub Actions](#continuous-integration-with-github-actions)
 
+[Troubleshooting](#troubleshooting)
+
 [Disclaimer](#disclaimer)
 
 [Contributors](#the-people-who-made-this-tester-possible)
-
----
-
-# Setup
-First you should comment out everything what prints to terminal eg "exit" at exit, printf's for debugging etc.
-Then modify your main loop:
-You should only read with readline and use your own prompt when you launch the program by yourself typing ./minishell into the terminal. You can check it this way:
-
-
-```c
-	if (isatty(fileno(stdin)))
-		shell->prompt = readline(shell->terminal_prompt);
-```
-
-Else if it is opened by another program/tester for example then use gnl as follows
-
-```c
-	char *line;
-	line = get_next_line(fileno(stdin));
-	shell->prompt = ft_strtrim(line, "\n");
-	free(line);
-```
-
-So it should look something like this:
-
-```c
-	if (isatty(fileno(stdin)))
-		shell->prompt = readline(shell->terminal_prompt);
-	else
-	{
-		char *line;
-		line = get_next_line(fileno(stdin));
-		shell->prompt = ft_strtrim(line, "\n");
-		free(line);
-	}
-```
-
-I think from this you pretty much can figure it out, it isn't a big change :)
 
 ---
 
@@ -144,6 +107,19 @@ mstest -h  # Display the usage instructions
 # Continuous Integration with GitHub Actions
 
 [How to Re-use Our CI/CD Framework For Your Own Minishell](https://github.com/LeaYeh/minishell?tab=readme-ov-file#how-to-re-use-our-cicd-framework-for-your-own-minishell)
+
+---
+
+# Troubleshooting
+
+## All my STDOUT tests fail
+
+  It is because you print your exit message to STDOUT instead of STDERR.
+
+  You can fix this in two ways:
+  - Check in your code if you are in "interactive mode" (`isatty()`) and only print the exit message if you are. This is how bash does it.
+  - Print the exit message to STDERR. In interactive mode, bash does it this way too (try out `exit 2>/dev/null`).<br>
+    For more information, see [here](https://github.com/LeaYeh/minishell/pull/270).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@
 
 # Menu
 
-[Install & Run](#how-to-install-and-run)
+- [Install & Run](#how-to-install-and-run)
 
-[Usage](#how-to-launch-the-tester)
+- [Usage](#how-to-launch-the-tester)
 
-[CI with GitHub Actions](#continuous-integration-with-github-actions)
+- [CI with GitHub Actions](#continuous-integration-with-github-actions)
 
-[Troubleshooting](#troubleshooting)
+- [Troubleshooting](#troubleshooting)
 
-[Disclaimer](#disclaimer)
+  - [All my STDOUT tests fail](#all-my-stdout-tests-fail)
 
-[Contributors](#the-people-who-made-this-tester-possible)
+- [Disclaimer](#disclaimer)
+
+- [Contributors](#the-people-who-made-this-tester-possible)
 
 ---
 

--- a/tester.sh
+++ b/tester.sh
@@ -9,7 +9,7 @@ OUTDIR=$MINISHELL_PATH/tester_output
 
 # Get the name of the minishell by running a command that produces an error
 # The name will then be filtered out from error messages
-MINISHELL_NAME=$(echo -n "forcing_error_message" | $MINISHELL_PATH/$EXECUTABLE 2>&1 | head -n 1 | awk -F: '{if ($0 ~ /:/) print $1; else print ""}')
+MINISHELL_NAME=$(echo -n "|" | $MINISHELL_PATH/$EXECUTABLE 2>&1 | head -n 1 | awk -F: '{if ($0 ~ /:/) print $1; else print ""}')
 
 VALGRIND_FLAGS=(
 	--errors-for-leak-kinds=all

--- a/tester.sh
+++ b/tester.sh
@@ -336,17 +336,15 @@ run_test() {
 				((ONE++))
 			fi
 			echo -ne "\033[1;33mSTD_ERR:\033[m "
-			stderr_minishell=$(cat "$TMP_OUTDIR/tmp_err_minishell")
-			stderr_bash=$(cat "$TMP_OUTDIR/tmp_err_bash")
-			if grep -q '^bash: line [0-9]*:' <<< "$stderr_bash" ; then
+			if grep -q '^bash: line [0-9]*:' "$TMP_OUTDIR/tmp_err_bash" ; then
 				# Normalize bash stderr by removing the program name and line number prefix
-				stderr_bash=$(sed 's/^bash: line [0-9]*:/:/' <<< "$stderr_bash")
+				sed -i 's/^bash: line [0-9]*:/:/' "$TMP_OUTDIR/tmp_err_bash"
 				# Normalize minishell stderr by removing its program name prefix
-				stderr_minishell=$(sed "s/^\\($MINISHELL_NAME: line [0-9]*:\\|$MINISHELL_NAME:\\)/:/" <<< "$stderr_minishell")
+				sed -i "s/^\\($MINISHELL_NAME: line [0-9]*:\\|$MINISHELL_NAME:\\)/:/" "$TMP_OUTDIR/tmp_err_minishell"
 				# Remove the next line after a specific syntax error message in bash stderr
-				stderr_bash=$(sed '/^: syntax error near unexpected token/{n; d}' <<< "$stderr_bash")
+				sed -i '/^: syntax error near unexpected token/{n; d}' "$TMP_OUTDIR/tmp_err_bash"
 			fi
-			if ! diff -q <(echo "$stderr_minishell") <(echo "$stderr_bash") >/dev/null ; then
+			if ! diff -q "$TMP_OUTDIR/tmp_err_minishell" "$TMP_OUTDIR/tmp_err_bash" >/dev/null ; then
 				echo -ne "❌  " | tr '\n' ' '
 				((TEST_KO_ERR++))
 				((FAILED++))

--- a/tester.sh
+++ b/tester.sh
@@ -268,41 +268,45 @@ print_title() {
 }
 
 run_tests() {
-	dir=$1
-	test_leaks=$2
-	no_env=$3
+	local dir=$1
+	local test_leaks=$2
+	local no_env=$3
+	local files
+
 	if [[ $dir == "all" ]] ; then
-		FILES="${RUNDIR}/cmds/**/*.sh"
+		files="${RUNDIR}/cmds/**/*.sh"
 	else
-		FILES="${RUNDIR}/cmds/${dir}/*"
+		files="${RUNDIR}/cmds/${dir}/*"
 	fi
-	for file in $FILES ; do
+	for file in $files ; do
 		run_test "$file" "$test_leaks" "$no_env"
 	done
 }
 
 run_tests_from_file() {
-	file=$1
-	test_leaks=$2
-	no_env=$3
+	local file=$1
+	local test_leaks=$2
+	local no_env=$3
+
 	run_test "$file" "$test_leaks" "$no_env"
 }
 
 run_tests_from_dir() {
-	dir=$1
-	test_leaks=$2
-	no_env=$3
-	FILES="${dir}/*"
-	for file in $FILES ; do
+	local dir=$1
+	local test_leaks=$2
+	local no_env=$3
+	local files="${dir}/*"
+
+	for file in $files ; do
 		run_test "$file" "$test_leaks" "$no_env"
 	done
-
 }
 
 run_test() {
-	file=$1
-	test_leaks=$2
-	no_env=$3
+	local file=$1
+	local test_leaks=$2
+	local no_env=$3
+
 	if [[ $no_env == "true" ]] ; then
 		env="env -i"
 	fi
@@ -328,14 +332,14 @@ run_test() {
 			printf "\033[1;35m%-4s\033[m" "  $i:	"
 			tmp_line_count=$line_count
 			while [[ $end_of_file == 0 ]] && [[ $line != \#* ]] && [[ $line != "" ]] ; do
-				INPUT+="$line$NL"
+				input+="$line$NL"
 				read -r line
 				end_of_file=$?
 				((line_count++))
 			done
-			echo -n "$INPUT" | eval "$env $valgrind $MINISHELL_PATH/$EXECUTABLE" 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
+			echo -n "$input" | eval "$env $valgrind $MINISHELL_PATH/$EXECUTABLE" 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
 			exit_minishell=$?
-			echo -n "enable -n .$NL$INPUT" | eval "$env bash --posix" 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
+			echo -n "enable -n .$NL$input" | eval "$env bash --posix" 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
 			exit_bash=$?
 			echo -ne "\033[1;34mSTD_OUT:\033[m "
 			if [[ $READLINE == "true" ]] ; then
@@ -433,7 +437,7 @@ run_test() {
 					echo -ne "✅ "
 				fi
 			fi
-			INPUT=""
+			input=""
 			((i++))
 			((TEST_COUNT++))
 			echo -e "\033[0;90m$file:$tmp_line_count\033[m  "


### PR DESCRIPTION
**Also:**
- Filter out the exit message from stderr.
- Put the filtered stderr into tester_output dir.
- Update the [README](https://github.com/LeaYeh/42_minishell_tester/blob/feat-readline-compatibility/README.md) accordingly. Remove the suggested code snippets.
