### PR TITLE
[FIX] Fix too high resource usage of valgrind

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -30,6 +30,7 @@ adjust_to_minishell() {
 	MINISHELL_EXIT_MSG=$(echo -n "" | $MINISHELL_PATH/$EXECUTABLE 2>&1 | sed "s/^$ESCAPED_PROMPT//")
 }
 
+export PATH="/bin:/usr/bin:/usr/sbin:$PATH"
 VALGRIND_FLAGS=(
 	--errors-for-leak-kinds=all
 	--leak-check=full


### PR DESCRIPTION
If the user has modified their PATH env variable, so that the path of f.e. `ls` is different than expected, valgrind will follow those child processes. In test cases with a lot of child processes, this can lead to lockups because of too high CPU and RAM usage.

A common example is when the user installs capt.