### PR TITLE
[FIX] Run without valgrind first to compare stdout and stderr

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -362,8 +362,9 @@ run_test() {
 			done
 
 			# Run the test
-			echo -n "$input" | eval "$env $valgrind $MINISHELL_PATH/$EXECUTABLE" 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
+			echo -n "$input" | eval "$env $MINISHELL_PATH/$EXECUTABLE" 2>"$TMP_OUTDIR/tmp_err_minishell" >"$TMP_OUTDIR/tmp_out_minishell"
 			exit_minishell=$?
+			echo -n "$input" | eval "$env $valgrind $MINISHELL_PATH/$EXECUTABLE" 2>"/dev/null" >"/dev/null"
 			echo -n "enable -n .$NL$input" | eval "$env bash --posix" 2>"$TMP_OUTDIR/tmp_err_bash" >"$TMP_OUTDIR/tmp_out_bash"
 			exit_bash=$?
 


### PR DESCRIPTION
When using the `vm` option, the tester currently executes the minishell with valgrind, and bash without valgrind and then compares the stdout/stderr. The problem is that when using valgrind it also creates/changes some environment variables, so the output will be different in some cases.

With this PR it will run the minishell twice per test case, once without valgrind, which will be used to compare the stdout/stderr/exit code, and once with valgrind (and discard all output from the shell) just to get the valgrind log-file to check for leaks.