### PR TITLE
[FIX] Fix detection of exit message in STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - File descriptor leak checks.
 - Crash detection.
 - Smart stderror comparison with bash.
-- Output failed test case and valgrind results to files.
+- Output failed test cases and valgrind results to files.
 - Updated test cases for updated subject (v7.1).
 - Subshell test cases.
 - Compatibility and tester speed-up with GitHub Actions.

--- a/cmds/crash/1_crash.sh
+++ b/cmds/crash/1_crash.sh
@@ -205,3 +205,5 @@ cd ~
 pwd
 cd -
 pwd
+
+/bin/echo $USER =intergalaktikus miaf*szomez

--- a/cmds/mand/0_compare_parsing.sh
+++ b/cmds/mand/0_compare_parsing.sh
@@ -47,7 +47,7 @@
 
 /bin/echo '$USER' "$USER" "text  ' text"
 
-/bin/echo $USER =intergalaktikus miaf*szomez
+/bin/echo $USER =intergalaktikus miaf szomez
 
 /bin/echo -n"-n" bonjour
 

--- a/tester.sh
+++ b/tester.sh
@@ -33,7 +33,7 @@ adjust_to_minishell() {
 }
 
 check_exit_stderr() {
-	if echo -n "exit" | $MINISHELL_PATH/$EXECUTABLE 2>/dev/null | grep -q "exit" ; then
+	if echo -n "exit 0" | $MINISHELL_PATH/$EXECUTABLE 2>/dev/null | grep -q 'exit$' ; then
 		echo -e "\033[1;31mERROR: Your minishell prints 'exit' to STDOUT instead of STDERR."
 		echo -e "All the STDOUT tests will fail because bash prints 'exit' to STDERR.\033[m"
 		echo -e "Find more information here:"


### PR DESCRIPTION
Bc I wanted to support all kinds of combinations between `readline` and `get_next_line`, I made a mistake in the exit message detection in STDOUT when minishell uses just normal `readline`.

The output of the test for the detection would look like this:
```
PROMPT$ exit   <- in STDOUT
exit           <- in STDERR
```
The tester then checks if `exit` gets printed to STDOUT. Because it is in the prompt line that always gets printed out by readline, the tester saw that and reported that the minishell prints the exit message to STDOUT instead of STDERR.

### Solution
Instead of testing with `exit`, test with `exit 0` so it can then use regex to check that `exit` is at the end of the line.
To also test the behavior of CTRL+D, it now also tests with `""`.