### PR TITLE
[FIX] Fix exit message filtering

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -24,7 +24,19 @@ adjust_to_minishell() {
 
 	# Get the name of the minishell by running a command that produces an error
 	# The name will then be filtered out from error messages
-	MINISHELL_ERR_NAME_HEX=$(echo -n "|" | eval $ENV $MINISHELL 2>&1 >/dev/null | awk -F: '{if ($0 ~ /:/) print $1; else print ""}' | to_hex)
+	ERROR_COMMANDS=(
+		'|'
+		'cd /MSTEST'
+		'""'
+		'\\'
+		'non-existent-command'
+	)
+	for cmd in "${ERROR_COMMANDS[@]}" ; do
+		MINISHELL_ERR_NAME_HEX=$(echo -n "$cmd" | eval $ENV $MINISHELL 2>&1 >/dev/null | awk -F: '{if ($0 ~ /:/) print $1; else print ""}' | to_hex)
+		if [[ -n $(from_hex "$MINISHELL_ERR_NAME_HEX") ]] ; then
+			break
+		fi
+	done
 
 	# Get the exit message of the minishell in stderr in case it needs to be filtered out
 	# The exit message should always get printed to stderr, bash does it too (see `exit 2>/dev/null`)

--- a/tester.sh
+++ b/tester.sh
@@ -156,7 +156,12 @@ main() {
 		echo "#                                 COMPILING ...                                #"
 		echo -e "# **************************************************************************** #\033[m"
 		if ! make -s -C $MINISHELL_PATH || [[ ! -f $MINISHELL_PATH/$EXECUTABLE ]] ; then
-			echo -e "\033[1;31mCOMPILING FAILED\033[m" && exit 1
+			echo -e "\033[1;31mCOMPILING FAILED\033[m"
+			if [[ -x $MINISHELL_PATH/$EXECUTABLE ]] || ([[ -f $MINISHELL_PATH/$EXECUTABLE ]] && chmod +x $MINISHELL_PATH/$EXECUTABLE) ; then
+				echo -e "\033[1;33mUSING EXISTING EXECUTABLE\033[m"
+			else
+				exit 1
+			fi
 		fi
 		echo -e "\033[1;34m# **************************************************************************** #\033[m"
 	elif ! make --question -s -C $MINISHELL_PATH &>/dev/null ; then
@@ -165,7 +170,12 @@ main() {
 		echo "#                                 COMPILING ...                                #"
 		echo -e "# **************************************************************************** #\033[m"
 		if ! make -s -C $MINISHELL_PATH || [[ ! -f $MINISHELL_PATH/$EXECUTABLE ]] ; then
-			echo -e "\033[1;31mCOMPILING FAILED\033[m" && exit 1
+			echo -e "\033[1;31mCOMPILING FAILED\033[m"
+			if [[ -x $MINISHELL_PATH/$EXECUTABLE ]] || ([[ -f $MINISHELL_PATH/$EXECUTABLE ]] && chmod +x $MINISHELL_PATH/$EXECUTABLE) ; then
+				echo -e "\033[1;33mUSING EXISTING EXECUTABLE\033[m"
+			else
+				exit 1
+			fi
 		fi
 		echo -e "\033[1;34m# **************************************************************************** #\033[m"
 	fi

--- a/tester.sh
+++ b/tester.sh
@@ -671,13 +671,13 @@ run_test() {
 				fi
 				from_hex <"$TMP_OUTDIR/tmp_err_minishell.hex" >"$TMP_OUTDIR/tmp_err_minishell"
 				from_hex <"$TMP_OUTDIR/tmp_err_bash.hex" >"$TMP_OUTDIR/tmp_err_bash"
-				if grep -q '^bash: line [0-9]*:' "$TMP_OUTDIR/tmp_err_bash" ; then
-					# Normalize bash stderr by removing the program name and line number prefix
-					sed -i 's/^bash: line [0-9]*:/:/' "$TMP_OUTDIR/tmp_err_bash"
+				if grep -q '^\(bash: line [0-9]*: \|bash: \)' "$TMP_OUTDIR/tmp_err_bash" ; then
 					# Normalize minishell stderr by removing its program name prefix
-					sed -i "s/^\\($MINISHELL_ERR_NAME: line [0-9]*:\\|$MINISHELL_ERR_NAME:\\)/:/" "$TMP_OUTDIR/tmp_err_minishell"
+					sed -i "s/^\\($MINISHELL_ERR_NAME: line [0-9]*: \\|$MINISHELL_ERR_NAME: \\)//" "$TMP_OUTDIR/tmp_err_minishell"
+					# Normalize bash stderr by removing the program name and line number prefixes
+					sed -i 's/^\(bash: line [0-9]*: \|bash: \)//' "$TMP_OUTDIR/tmp_err_bash"
 					# Remove the next line after a specific syntax error message in bash stderr
-					sed -i '/^: syntax error near unexpected token/{n; d}' "$TMP_OUTDIR/tmp_err_bash"
+					sed -i '/^syntax error near unexpected token/{n; d}' "$TMP_OUTDIR/tmp_err_bash"
 				fi
 				if ! diff -q "$TMP_OUTDIR/tmp_err_minishell" "$TMP_OUTDIR/tmp_err_bash" >/dev/null ; then
 					echo -ne "❌  " | tr '\n' ' '

--- a/tester.sh
+++ b/tester.sh
@@ -13,7 +13,7 @@ adjust_to_minishell() {
 	local minishell_stdout
 
 	# libintercept will exit the minishell at the first call of readline or read
-	minishell_stdout=$(echo -n "" | eval $ENV INTERCEPT_EXIT=1 $MINISHELL 2>/dev/null)
+	minishell_stdout=$(echo -n "" | eval $ENV LIBINTERCEPT_EXIT=1 $MINISHELL 2>/dev/null)
 
 	# Get any message that minishell prints at the start
 	# head -1 keeps all but the last line, so it will drop a single line

--- a/tester.sh
+++ b/tester.sh
@@ -50,15 +50,15 @@ adjust_to_minishell() {
 	MINISHELL_PROMPT=$(from_hex "$MINISHELL_PROMPT_HEX")
 	MINISHELL_ERR_NAME=$(from_hex "$MINISHELL_ERR_NAME_HEX")
 	MINISHELL_EXIT_MSG_STDERR=$(from_hex "$MINISHELL_EXIT_MSG_STDERR_HEX")
-	MINISHELL_EXIT_MSG_STDERR_EOF_HEX=$(from_hex "$MINISHELL_EXIT_MSG_STDERR_EOF_HEX")
-	MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX=$(from_hex "$MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX")
+	MINISHELL_EXIT_MSG_STDERR_EOF=$(from_hex "$MINISHELL_EXIT_MSG_STDERR_EOF_HEX")
+	MINISHELL_EXIT_MSG_STDERR_BUILTIN=$(from_hex "$MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX")
 	MINISHELL_EXIT_MSG_STDOUT=$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_HEX")
-	MINISHELL_EXIT_MSG_STDOUT_EOF_HEX=$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_EOF_HEX")
-	MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX=$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX")
+	MINISHELL_EXIT_MSG_STDOUT_EOF=$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_EOF_HEX")
+	MINISHELL_EXIT_MSG_STDOUT_BUILTIN=$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX")
 
-	if [[ -n $MINISHELL_START_MSG_HEX || -n $MINISHELL_PROMPT_HEX || -n $MINISHELL_ERR_NAME_HEX ||
-		-n $MINISHELL_EXIT_MSG_STDERR_HEX || -n $MINISHELL_EXIT_MSG_STDERR_EOF_HEX || -n $MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX ||
-		-n $MINISHELL_EXIT_MSG_STDOUT_HEX || -n $MINISHELL_EXIT_MSG_STDOUT_EOF_HEX || -n $MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX ]] ; then
+	if [[ -n $MINISHELL_START_MSG || -n $MINISHELL_PROMPT || -n $MINISHELL_ERR_NAME ||
+		-n $MINISHELL_EXIT_MSG_STDERR || -n $MINISHELL_EXIT_MSG_STDERR_EOF || -n $MINISHELL_EXIT_MSG_STDERR_BUILTIN ||
+		-n $MINISHELL_EXIT_MSG_STDOUT || -n $MINISHELL_EXIT_MSG_STDOUT_EOF || -n $MINISHELL_EXIT_MSG_STDOUT_BUILTIN ]] ; then
 		echo -e "\033[1;36m# **************************************************************************** #"
 		echo "#                     ADJUSTED OUTPUT FILTERS FOR MINISHELL                    #"
 		echo -e "# **************************************************************************** #\033[m"
@@ -78,26 +78,26 @@ adjust_to_minishell() {
 			echo -e "\033[1;36mExit Message Stderr:\033[0m"
 			echo -e "$MINISHELL_EXIT_MSG_STDERR"
 		else
-			if [[ -n $MINISHELL_EXIT_MSG_STDERR_EOF_HEX ]] ; then
+			if [[ -n $MINISHELL_EXIT_MSG_STDERR_EOF ]] ; then
 				echo -e "\033[1;36mExit Message Stderr EOF (Ctrl+D):\033[0m"
-				echo -e "$(from_hex "$MINISHELL_EXIT_MSG_STDERR_EOF_HEX")"
+				echo -e "$MINISHELL_EXIT_MSG_STDERR_EOF"
 			fi
-			if [[ -n $MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX ]] ; then
+			if [[ -n $MINISHELL_EXIT_MSG_STDERR_BUILTIN ]] ; then
 				echo -e "\033[1;36mExit Message Stderr Builtin:\033[0m"
-				echo -e "$(from_hex "$MINISHELL_EXIT_MSG_STDERR_BUILTIN_HEX")"
+				echo -e "$MINISHELL_EXIT_MSG_STDERR_BUILTIN"
 			fi
 		fi
-		if [[ -n $MINISHELL_EXIT_MSG_STDOUT_HEX ]] ; then
+		if [[ -n $MINISHELL_EXIT_MSG_STDOUT ]] ; then
 			echo -e "\033[1;36mExit Message Stdout:\033[0m"
 			echo -e "$MINISHELL_EXIT_MSG_STDOUT"
 		else
-			if [[ -n $MINISHELL_EXIT_MSG_STDOUT_EOF_HEX ]] ; then
+			if [[ -n $MINISHELL_EXIT_MSG_STDOUT_EOF ]] ; then
 				echo -e "\033[1;36mExit Message Stdout EOF (Ctrl+D):\033[0m"
-				echo -e "$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_EOF_HEX")"
+				echo -e "$MINISHELL_EXIT_MSG_STDOUT_EOF"
 			fi
-			if [[ -n $MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX ]] ; then
+			if [[ -n $MINISHELL_EXIT_MSG_STDOUT_BUILTIN ]] ; then
 				echo -e "\033[1;36mExit Message Stdout Builtin:\033[0m"
-				echo -e "$(from_hex "$MINISHELL_EXIT_MSG_STDOUT_BUILTIN_HEX")"
+				echo -e "$MINISHELL_EXIT_MSG_STDOUT_BUILTIN"
 			fi
 		fi
 		echo -e "\033[1;36m# **************************************************************************** #\033[m"

--- a/utils/libintercept/intercept.h
+++ b/utils/libintercept/intercept.h
@@ -27,8 +27,8 @@
 #ifndef INTERCEPT_H
 # define INTERCEPT_H
 
-# define DEBUG_ENV_VAR "INTERCEPT_DEBUG"
-# define EXIT_ENV_VAR  "INTERCEPT_EXIT"
+# define DEBUG_ENV_VAR "LIBINTERCEPT_DEBUG"
+# define EXIT_ENV_VAR  "LIBINTERCEPT_EXIT"
 
 typedef enum e_flags {
 	NONE       = 0,

--- a/utils/libintercept/intercept_readline.c
+++ b/utils/libintercept/intercept_readline.c
@@ -46,6 +46,9 @@ static char *read_line_tty_prompt(t_rl_func orig_readline, const char *prompt)
 		line = orig_readline(prompt);
 	}
 	else {
+		if (IS_FLAG_SET(FLAG_DEBUG)) {
+			dprintf(STDERR_FILENO, "Calling getline instead\n");
+		}
 		read = getline(&line, &len, stdin);
 		if (read == -1) {
 			free(line);


### PR DESCRIPTION
There were 3 issues:
1. I used the wrong variables in one place 🤦
2. For Minishells that don't have a program name prefix in their error message, the tester still filtered out everything until the first colon.
3. Katrin's minishell didn't print any error message for syntax errors like a simple `|`, therefore the minishell error name couldn't get filtered out for other cases.

The behavior of bash and bash --posix is different for error messages - normal bash sometimes doesn't print `bash: `, while --posix always prints it.
Therefore, the easiest solution is to filter out also the colon and the space after any program name prefix.

Also, multiple commands get tested now to get the minishell error name.