### PR TITLE
[FEAT] Add compatibility for alternative rundirs

### DIFF
--- a/tester.sh
+++ b/tester.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env -S --default-signal bash
 
-# Change if you store the tester in another PATH
 MINISHELL_PATH=$(pwd)
 EXECUTABLE=minishell
-RUNDIR=$HOME/42_minishell_tester
+RUNDIR=$(dirname "$0")
 DATE=$(date +%Y-%m-%d_%H.%M.%S)
 OUTDIR=$MINISHELL_PATH/mstest_output_$DATE
 TMP_OUTDIR=$(mktemp -d)

--- a/tester.sh
+++ b/tester.sh
@@ -2,7 +2,7 @@
 
 MINISHELL_PATH=$(pwd)
 EXECUTABLE=minishell
-RUNDIR=$(dirname "$0")
+RUNDIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 DATE=$(date +%Y-%m-%d_%H.%M.%S)
 OUTDIR=$MINISHELL_PATH/mstest_output_$DATE
 TMP_OUTDIR=$(mktemp -d)


### PR DESCRIPTION
Use the script's dynamic rundir instead of a hardcoded path.
Allows the user to place the tester in any directory without having to modify the script.